### PR TITLE
enable ui-table to be configured via ui_control

### DIFF
--- a/node-red-node-ui-table/locales/en-US/node.json
+++ b/node-red-node-ui-table/locales/en-US/node.json
@@ -3,7 +3,8 @@
         "label" : {
             "group" : "Group",
             "size" : "Size",
-            "send" : "Send data on click "
+            "send" : "Send data on click ",
+            "sendLayout" : "Send layout on change "
         },
         "error": {
             "no-group": "group not configured"

--- a/node-red-node-ui-table/locales/en-US/node.json
+++ b/node-red-node-ui-table/locales/en-US/node.json
@@ -3,8 +3,7 @@
         "label" : {
             "group" : "Group",
             "size" : "Size",
-            "send" : "Send data on click ",
-            "sendLayout" : "Send layout on change "
+            "send" : "Send data on click "
         },
         "error": {
             "no-group": "group not configured"

--- a/node-red-node-ui-table/node.html
+++ b/node-red-node-ui-table/node.html
@@ -37,7 +37,10 @@
     </div>
     <div class="form-row node-input-column-container-row">
         <label for="node-input-width" style="vertical-align:top"><i class="fa fa-list-alt"></i> Columns</label>
-        <span style="float:right"><span data-i18n='table.label.send'>&nbsp;</span><input type="checkbox" id="node-input-cts" style="display:inline-block; width:auto; vertical-align:top;"></span>
+        <span style="float:right">
+            <span data-i18n='table.label.send'>&nbsp;</span><input type="checkbox" id="node-input-cts" style="display:inline-block; width:auto; vertical-align:top;">
+            <span data-i18n='table.label.sendLayout'>&nbsp;</span><input type="checkbox" id="node-input-slc" style="display:inline-block; width:auto; vertical-align:top;">
+        </span>
         <ol id="node-input-column-container"></ol>
     </div>
 </script>
@@ -65,7 +68,8 @@
             height: { value: 0 },
             columns: { value: [] },
             outputs: { value: 0 },
-            cts: { value: false }
+            cts: { value: false },
+            slc: { value: false }  // send layout changes
         },
         inputs: 1,
         outputs: 0,
@@ -182,8 +186,9 @@
                 node.columns.push(c);
             });
             var that = this;
+            that.outputs = 0;
             if ($("#node-input-cts").is(":checked")) { that.outputs = 1; }
-            else { that.outputs = 0; }
+            if ($("#node-input-slc").is(":checked")) { that.cts=true; that.outputs = 2; }
         },
         oneditresize: function(size) {
             var rows = $("#dialog-form>div:not(.node-input-column-container-row)");

--- a/node-red-node-ui-table/node.html
+++ b/node-red-node-ui-table/node.html
@@ -39,7 +39,6 @@
         <label for="node-input-width" style="vertical-align:top"><i class="fa fa-list-alt"></i> Columns</label>
         <span style="float:right">
             <span data-i18n='table.label.send'>&nbsp;</span><input type="checkbox" id="node-input-cts" style="display:inline-block; width:auto; vertical-align:top;">
-            <span data-i18n='table.label.sendLayout'>&nbsp;</span><input type="checkbox" id="node-input-slc" style="display:inline-block; width:auto; vertical-align:top;">
         </span>
         <ol id="node-input-column-container"></ol>
     </div>
@@ -68,8 +67,7 @@
             height: { value: 0 },
             columns: { value: [] },
             outputs: { value: 0 },
-            cts: { value: false },
-            slc: { value: false }  // send layout changes
+            cts: { value: false }
         },
         inputs: 1,
         outputs: 0,
@@ -186,9 +184,8 @@
                 node.columns.push(c);
             });
             var that = this;
-            that.outputs = 0;
             if ($("#node-input-cts").is(":checked")) { that.outputs = 1; }
-            if ($("#node-input-slc").is(":checked")) { that.cts=true; that.outputs = 2; }
+                else that.outputs = 0;
         },
         oneditresize: function(size) {
             var rows = $("#dialog-form>div:not(.node-input-column-container-row)");

--- a/node-red-node-ui-table/node.js
+++ b/node-red-node-ui-table/node.js
@@ -76,13 +76,14 @@ module.exports = function (RED) {
                         $scope.inited = false;
                         $scope.tabledata = [];
                         var tablediv;
+                        // (columndata.length === 0) ? true : false,
                         var createTable = function(basediv, tabledata, columndata, outputs, ui_control) {
-                            var y = (columndata.length === 0) ? 25 : 32;
+                            var y = ((ui_control && ui_control.columns.length > 0) || columndata.length > 0) ? 32 : 25;
                             var opts = {
                                 data: tabledata,
                                 layout: (ui_control && ui_control.layout) ? ui_control.layout : 'fitColumns',
-                                columns: columndata,
-                                autoColumns: (columndata.length === 0) ? true : false,
+                                columns: (ui_control && ui_control.columns) ? ui_control.columns : columndata,
+                                autoColumns: ((ui_control && ui_control.columns.length>0) || columndata.length > 0) ? false : true,
                                 movableColumns: (ui_control && (typeof ui_control.movableColumns=="boolean")) ? ui_control.movableColumns : true,
                                 height: tabledata.length * y + 26
                             }
@@ -138,7 +139,7 @@ module.exports = function (RED) {
                                         }
                                     });
 
-                                    $scope.config.columns = msg.ui_control.columns;
+                                   $scope.config.ui_control.columns = msg.ui_control.columns;
                                 }
                             }
 

--- a/node-red-node-ui-table/node.js
+++ b/node-red-node-ui-table/node.js
@@ -64,7 +64,10 @@ module.exports = function (RED) {
                     group: config.group,
                     forwardInputMessages: false,
                     beforeEmit: function (msg, value) {
-                        return { msg: { payload: value } };
+                        if (msg.hasOwnProperty("ui_control") && Array.isArray(msg.ui_control))
+                            return {msg: {payload: value, ui_control: msg.ui_control } };
+                        else
+                            return { msg: { payload: value } };
                     },
                     beforeSend: function (msg, orig) {
                         if (orig) { return orig.msg; }
@@ -108,7 +111,15 @@ module.exports = function (RED) {
                                     $scope.tabledata = msg.payload;
                                     return;
                                 }
-                                createTable(tablediv,msg.payload,$scope.config.columns,$scope.config.outputs);
+                                if ( msg.hasOwnProperty("ui_control") && Array.isArray(msg.ui_control)) {
+                                    if ($scope.inited == false) {
+                                        $scope.config.columns = msg.ui_control;
+                                        return;
+                                    }
+                                    createTable(tablediv,msg.payload,msg.ui_control,$scope.config.outputs);
+                                } else {
+                                    createTable(tablediv,msg.payload,$scope.config.columns,$scope.config.outputs);
+                                }
                             }
                         });
                     }

--- a/node-red-node-ui-table/node.js
+++ b/node-red-node-ui-table/node.js
@@ -63,62 +63,50 @@ module.exports = function (RED) {
                     order: config.order,
                     group: config.group,
                     forwardInputMessages: false,
-                    columns: config.columns,
+
                     beforeEmit: function (msg, value) {
                         return {msg: {
                             payload: value, 
                             ui_control: (msg.hasOwnProperty("ui_control")) ? msg.ui_control : undefined,
-                            topic: (msg.hasOwnProperty("topic")) ? msg.topic : undefined,
                         }};
                     },
                     beforeSend: function (msg, orig) {
-                        if (orig) { 
-                            if (orig.msg.hasOwnProperty("layout"))
-                                return [null,orig.msg];
-                            else
-                                return [orig.msg,null];
-                            }
+                        if (orig) { return orig.msg; }
                     },
                     initController: function ($scope, events) {
                         $scope.inited = false;
                         $scope.tabledata = [];
                         var tablediv;
-                        // (columndata.length === 0) ? true : false,
                         var createTable = function(basediv, tabledata, columndata, outputs, ui_control) {
-                            var y = ((ui_control && ui_control.columns.length > 0) || columndata.length > 0) ? 32 : 25;
-                            var opts = {
-                                data: tabledata,
-                                layout: (ui_control && ui_control.layout) ? ui_control.layout : 'fitColumns',
-                                columns: (ui_control && ui_control.columns) ? ui_control.columns : columndata,
-                                autoColumns: ((ui_control && ui_control.columns.length>0) || columndata.length > 0) ? false : true,
-                                movableColumns: (ui_control && (typeof ui_control.movableColumns=="boolean")) ? ui_control.movableColumns : true,
-                                groupBy: (ui_control && ui_control.groupBy) ? ui_control.groupBy : undefined,
-                                groupHeader: (ui_control && ui_control.groupHeader) ? ui_control.groupHeader : undefined,
-                                height: tabledata.length * y + 26,
-                            }
+                            if (!ui_control || !ui_control.tabulator) {
+                                var y = (columndata.length === 0) ? 25 : 32;
+                                var opts = {
+                                    data: tabledata,
+                                    layout: 'fitColumns',
+                                    columns: columndata,
+                                    autoColumns: columndata.length == 0,
+                                    movableColumns: true,
+                                    height: tabledata.length * y + 26
+                                }
+                            } else { // configuration via ui_control
+                                var y = (ui_control.tabulator.columns.length > 0) ? 32 : 25;
+                                var opts = ui_control.tabulator;
+                                opts.data = tabledata;
+                                if (!ui_control.tabulator.layout) opts.layout = 'fitColumns';
+                                if (!ui_control.tabulator.movableColumns) opts.movableColumns = true;
+                                if (!ui_control.tabulator.columns) opts.columns = columndata;
+                                if (!ui_control.tabulator.autoColumns) autoColumns = columndata.length == 0;
+                                if (!ui_control.customHeight) opts.height= tabledata.length * y + 26;
+                                    else opts.height= ui_control.customHeight * y + 26;
+                            } // end of configuration via ui_control
+
                             if (outputs > 0) {
                                 opts.cellClick = function(e, cell) {
-                                    $scope.send({origin:"ui-table",topic:cell.getField(),payload:cell.getData()});
+                                    $scope.send({topic:cell.getField(),payload:cell.getData()});
                                 };
-                                if (opts.movableColumns) {
-                                    opts.columnMoved = function(column, columns){
-                                        console.log(columns);
-                                        var newColumns=[];
-                                        columns.forEach(function (column) {
-                                            newColumns.push({"field": column._column.field});
-                                        });
-                                        $scope.send({origin:"ui-table",topic:$scope.config.topic,layout:"columnMoved",payload:newColumns});
-                                    }
+                            }
 
-                                }
-                                opts.columnResized = function(column){
-                                    $scope.send({origin:"ui-table",topic:$scope.config.topic,layout:"columnResized",payload:{"field":column._column.field,"width":column._column.width,"widthStyled":column._column.widthStyled}});
-                                };
-                            }
-                            if (Array.isArray(opts.data)){
-                                console.log(opts);
-                                var table = new Tabulator(basediv, opts);
-                            }
+                            var table = new Tabulator(basediv, opts);
                         };
                         $scope.init = function (config) {
                             $scope.config = config;
@@ -130,71 +118,51 @@ module.exports = function (RED) {
                                     createTable(tablediv,$scope.tabledata,$scope.config.columns,$scope.config.outputs,$scope.config.ui_control);
                                     $scope.tabledata = [];
                                 }
-                            }, 200); // lowest setting on my browser ... fails sometimes
+                            }, 200); // lowest setting on my side ... still fails sometimes ;)
                         };
                         $scope.$watch('msg', function (msg) {
-                            if (msg && msg.hasOwnProperty("origin") && (msg.origin=="ui-table")) return;
-                            if (msg && msg.hasOwnProperty("topic")) $scope.config.topic=msg.topic;
-
+                            if (msg && msg.hasOwnProperty("ui_control") && msg.ui_control.hasOwnProperty("callback")) return; // to avoid loopback from callbacks. No better solution jet. Help needed.
                             if (msg && msg.hasOwnProperty("payload") && Array.isArray(msg.payload)) {
                                 $scope.tabledata = msg.payload;
                             }
                             
+                            // configuration via ui_control
                             if (msg && msg.hasOwnProperty("ui_control")) {
-                                if (!$scope.config.ui_control) {
-                                    $scope.config.ui_control={};
-                                }
+
                                 var addValueOrFunction = function (config,param,value) {
-                                    
                                     if (typeof String.prototype.parseFunction != 'function') {
                                         String.prototype.parseFunction = function () {
                                             var funcReg = /function *\(([^()]*)\)[ \n\t]*{(.*)}/gmi;
                                             var match = funcReg.exec(this.replace(/\n/g, ' '));
-                                    
                                             if(match) {
                                                 return new Function(match[1].split(','), match[2]);
                                             }
-                                    
                                             return null;
                                         };
                                     }
+                                    var valueFunction;
+                                    if (typeof value === "string" && (valueFunction = value.parseFunction())) {
+                                        config[param]=valueFunction.bind($scope); // to enable this.send() for callback functions.
+                                    }
+                                    else config[param]= value;
+                                }
 
-                                    if ((typeof value === "string") && value.includes('{') && value.includes('}')) {
-                                        config[param]= value.parseFunction();
-                                    } else {
-                                        config[param]= value;
+                                var addObject = function (destinationObject,sourceObject) {
+                                    for (var element in sourceObject) {
+                                        if (!destinationObject[element]) destinationObject[element]=(Array.isArray(sourceObject[element]))? [] : {};
+                                        if (typeof sourceObject[element] === "object") {
+                                            addObject(destinationObject[element],sourceObject[element])
+                                        } else {
+                                            addValueOrFunction(destinationObject,element,sourceObject[element]);
+                                        }
                                     }
                                 }
 
-                                if (msg.ui_control.hasOwnProperty("layout") && typeof msg.ui_control.layout == "string") {
-                                    $scope.config.ui_control.layout=msg.ui_control.layout;
-                                }
-                                if (msg.ui_control.hasOwnProperty("movableColumns") && typeof msg.ui_control.movableColumns == "boolean") {
-                                    $scope.config.ui_control.movableColumns=msg.ui_control.movableColumns;
-                                }
-                                if (msg.ui_control.hasOwnProperty("groupBy")) {
-                                    addValueOrFunction($scope.config.ui_control,"groupBy",msg.ui_control.groupBy);
-                                }
-                                if (msg.ui_control.hasOwnProperty("groupHeader")) {
-                                    addValueOrFunction($scope.config.ui_control,"groupHeader",msg.ui_control.groupHeader);
-                                }
+                                if (!$scope.config.ui_control) { $scope.config.ui_control={}; }
 
-                                if (msg.ui_control.hasOwnProperty("columns") && Array.isArray(msg.ui_control.columns)) {
-                                    // creates functions for color and legend properties if value includes {}
-                                    msg.ui_control.columns.forEach(function (element) {
-                                        if (element.hasOwnProperty("formatterParams")) {
-                                            for (var prop in element.formatterParams) {
-                                                if ((element.formatterParams.hasOwnProperty("color") ||
-                                                element.formatterParams.hasOwnProperty("legend"))) {
-                                                    addValueOrFunction(element.formatterParams,prop,element.formatterParams[prop])
-                                                }
-                                            }
-                                        }
-                                    });
+                                addObject($scope.config.ui_control,msg.ui_control);
 
-                                   $scope.config.ui_control.columns = msg.ui_control.columns;
-                                }
-                            }
+                            } // end off configuration via ui_control
 
                             if ($scope.inited == false) {
                                 return;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

I'm not an expert in custom  ui nodes so sorry if I have done everything/something wrong. I`m not a professional programmer and neither are my javascript skills the best.

For my project it would be nice if the ui-table could be configured via msg.ui_control. All data is already in my flow so retyping everything into the node configuration in many instances was not a nice option. Just when I was looking for infos in the forum about ui-table I found out that I`m not the only one so I thought it was a good idea to do a pr.

So here it is, very simple implementation. If you send together with the msg.payload an array in msg.ui_control with one object per column like this it works perfectly. The property names do not match the names in the ui but this is what I found when i export an a configured table note. Here is my example:

![image](https://user-images.githubusercontent.com/15779507/67726141-2845c980-f9e5-11e9-842e-5817738ebe8a.png)

I do not know what the "formatterParams" object is good for and if it is used. If it is necessary but in all cases the same perhaps I should add it in the beforeEmit function. And perhaps "translate" the property names to match the names in the ui (formatter = format and field = property)

Sorry if I took the wrong path here. I did not dig very deep into your code.
Looking forward to your comments

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
