### PR TITLE
Add ui_webcam node

### DIFF
--- a/node-red-node-ui-webcam/LICENSE
+++ b/node-red-node-ui-webcam/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/node-red-node-ui-webcam/README.md
+++ b/node-red-node-ui-webcam/README.md
@@ -1,0 +1,35 @@
+node-red-node-ui-webcam
+============================
+
+A Node-RED UI widget node that allows images to be captured from the dashboard.
+
+## Install
+
+Either use the Editor - Menu - Manage Palette - Install option, or run the following command in your Node-RED user directory (typically `~/.node-red`) after installing node-red-dashboard:
+
+        npm i node-red-node-ui-webcam
+
+## Usage
+
+The node provides UI widget that will display a live image from the web camera
+on the device running the dashboard.
+
+The user can click a button to capture an image which is then sent by the node
+as a Buffer object contain the image in png format.
+
+If a message is passed to the `ui_webcam` node with the `capture` property set,
+and if the webcam has been activated on the dashboard, it will capture an image
+without the user having to click on the button.
+
+## Browser Support
+
+This node will work in all modern browsers, but not IE.
+
+If you are accessing the dashboard remotely (not via `localhost`), then you must
+use HTTPS otherwise the browser will block access to the webcam.
+
+## Privacy
+
+Before the webcam can be activated, the browser will ask the user's permission for
+the page to access the device. The node cannot capture images until the user
+has given their permission.

--- a/node-red-node-ui-webcam/package.json
+++ b/node-red-node-ui-webcam/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "node-red-node-ui-webcam",
+    "version": "0.1.0",
+    "description": "A Node-RED ui node to capture images from a webcam.",
+    "author": "Nick O'Leary",
+    "license": "Apache-2.0",
+    "keywords": [
+        "node-red",
+        "node-red-dashboard",
+        "webcam"
+    ],
+    "bugs": {
+        "url": "https://github.com/node-red/node-red-ui-nodes/issues"
+    },
+    "homepage": "https://github.com/node-red/node-red-ui-nodes/node-red-node-ui-webcam",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/node-red/node-red-ui-nodes.git"
+    },
+    "node-red": {
+        "nodes": {
+            "ui_webcam": "ui_webcam.js"
+        }
+    }
+}

--- a/node-red-node-ui-webcam/ui_webcam.html
+++ b/node-red-node-ui-webcam/ui_webcam.html
@@ -1,0 +1,112 @@
+<!--
+  Copyright 2020 OpenJS Foundation
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/javascript">
+    RED.nodes.registerType('ui_webcam',{
+        category: 'dashboard',
+        color: 'rgb( 63, 173, 181)',
+        defaults: {
+            group: {type: 'ui_group', required:true},
+            order: {value: 0},
+            width: {
+                value: 0,
+                validate: function(v) {
+                    var valid = true
+                    var width = v||0;
+                    var currentGroup = $('#node-input-group').val()|| this.group;
+                    var groupNode = RED.nodes.node(currentGroup);
+                    valid = !groupNode || +width <= +groupNode.width;
+                    $("#node-input-size").toggleClass("input-error",!valid);
+                    return valid;
+                }},
+            height: {value: 0},
+            name: {value: ''},
+            countdown: { value: false },
+            autoStart: { value: false }
+        },
+        inputs:1,
+        outputs:1,
+        icon: "font-awesome/fa-camera",
+        paletteLabel: "webcam",
+        label: function() {
+            return this.name||"webcam";
+        },
+        labelStyle: function() {
+            return this.name?"node_label_italic":"";
+        },
+        oneditprepare: function() {
+            $("#node-input-size").elementSizer({
+                width: "#node-input-width",
+                height: "#node-input-height",
+                group: "#node-input-group"
+            });
+        },
+        oneditsave: function() {
+            // var ts = $("#node-input-select-timeslice").val();
+            // if (ts === 'once') {
+            //     $("#node-input-timeslice").val("")
+            // }
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="ui_webcam">
+    <div class="form-row" id="template-row-group">
+        <label for="node-input-group"><i class="fa fa-table"></i> Group</span></label>
+        <input type="text" id="node-input-group">
+    </div>
+    <div class="form-row" id="template-row-size">
+        <label><i class="fa fa-object-group"></i> Size</span></label>
+        <input type="hidden" id="node-input-width">
+        <input type="hidden" id="node-input-height">
+        <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <br />
+    <div class="form-row" style="min-width: 470px">
+        <label style="vertical-align: top"><i class="fa fa-cog"></i> Options</label>
+        <div style="display: inline-block; min-width: 350px; width: calc(100% - 120px);">
+            <div class="form-row">
+                <label style="width: auto" for="node-input-autoStart">
+                    <input style="width:auto; margin: 0" type="checkbox" id="node-input-autoStart"> Start webcam automatically
+                </label>
+            </div>
+            <div class="form-row">
+                <label style="width: auto" for="node-input-countdown">
+                    <input style="width:auto; margin: 0" type="checkbox" id="node-input-countdown"> Use 5 second countdown when triggered
+                </label>
+            </div>
+        </div>
+
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="ui_webcam">
+    <p>A Node Red dashboard ui node to capture images from the browser's webcam.</p>
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt>capture</dt>
+        <dd>If set, this will trigger the webcam to capture an image. The webcam must
+            have been activated on the dashboard first.</dd>
+    </dl>
+    <h3>Outputs</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">Buffer</span></dt>
+        <dd>The captured image as a png.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p></p>
+</script>

--- a/node-red-node-ui-webcam/ui_webcam.html
+++ b/node-red-node-ui-webcam/ui_webcam.html
@@ -32,7 +32,8 @@
             height: {value: 0},
             name: {value: ''},
             countdown: { value: false },
-            autoStart: { value: false }
+            autoStart: { value: false },
+            format: { value:"png" }
         },
         inputs:1,
         outputs:1,
@@ -84,6 +85,13 @@
                 <label style="width: auto" for="node-input-countdown">
                     <input style="width:auto; margin: 0" type="checkbox" id="node-input-countdown"> Use 5 second countdown when triggered
                 </label>
+            </div>
+            <div class="form-row">
+                <label for="node-input-format">Image format </label>
+                <select id="node-input-format">
+                    <option value="png">png</option>
+                    <option value="jpeg">jpeg</option>
+                </select>
             </div>
         </div>
 

--- a/node-red-node-ui-webcam/ui_webcam.js
+++ b/node-red-node-ui-webcam/ui_webcam.js
@@ -168,6 +168,10 @@ module.exports = function(RED) {
                      */
                     initController: function($scope) {
 
+                        $scope.$on('$destroy', function() {
+                            stopActiveTracks();
+                        });
+
                         $scope.init = function (config) {
                             console.log("ui_webcam: initialised config:",config);
                             $scope.config = config;
@@ -239,6 +243,7 @@ module.exports = function(RED) {
                                     $("#webcam_"+$scope.$id).addClass("active")
                                     var playbackEl = document.querySelector("video#ui_webcam_playback_"+$scope.$id);
                                     playbackEl.srcObject = stream;
+                                    $scope.data.stream = stream;
                                     $("#ui_webcam_toolbar_"+$scope.$id).show();
                                     if (activeCamera === null) {
                                         activeCamera = stream.getTracks()[0].getSettings().deviceId;
@@ -246,15 +251,20 @@ module.exports = function(RED) {
                                 }).catch(handleError);
                             }
                         }
-                        $scope.disableCamera = function() {
-                            var playbackEl = document.querySelector("video#ui_webcam_playback_"+$scope.$id);
-                            if (playbackEl.srcObject) {
-                                var tracks = playbackEl.srcObject.getTracks();
+                        function stopActiveTracks() {
+                            if ($scope.data.stream) {
+                                var tracks = $scope.data.stream.getTracks();
                                 tracks.forEach(function(track) {
                                     track.stop();
                                 });
                             }
+                            $scope.data.stream = null;
+                        }
+                        $scope.disableCamera = function() {
+                            stopActiveTracks();
+                            var playbackEl = document.querySelector("video#ui_webcam_playback_"+$scope.$id);
                             playbackEl.srcObject = null;
+
                             active = false;
                             $("#ui_webcam_btn_enable_"+$scope.$id).show();
                             $("#ui_webcam_toolbar_"+$scope.$id).hide();

--- a/node-red-node-ui-webcam/ui_webcam.js
+++ b/node-red-node-ui-webcam/ui_webcam.js
@@ -264,7 +264,9 @@ module.exports = function(RED) {
                         function countdownSnap(c) {
                             if (c === 0) {
                                 $("#ui_webcam_playback_container_"+$scope.$id+" .ui-webcam-count").text("")
-                                return takePhoto();
+                                var imgSrc = takePhoto();
+                                $scope.send({payload:imgSrc});
+                                return;
                             }
                             $("#ui_webcam_playback_container_"+$scope.$id+" .ui-webcam-count").text(c)
                             activeTimeout = setTimeout(function() {

--- a/node-red-node-ui-webcam/ui_webcam.js
+++ b/node-red-node-ui-webcam/ui_webcam.js
@@ -155,9 +155,8 @@ module.exports = function(RED) {
                     },
                     beforeSend: function (msg, orig) {
                         if (orig) {
-                            if (/^data:image\/png;base64,/.test(orig.msg.payload)) {
-                                orig.msg.payload = Buffer.from(orig.msg.payload.substring(22),'base64')
-                            }
+                            var urlPreamble = "data:image/"+(config.format||"png")+";base64,";
+                            orig.msg.payload = Buffer.from(orig.msg.payload.substring(urlPreamble.length),'base64')
                             return orig.msg;
                         }
                     },
@@ -173,7 +172,7 @@ module.exports = function(RED) {
                         });
 
                         $scope.init = function (config) {
-                            console.log("ui_webcam: initialised config:",config);
+                            // console.log("ui_webcam: initialised config:",config);
                             $scope.config = config;
                             if ($scope.config.autoStart) {
                                 setTimeout(function() {
@@ -303,7 +302,7 @@ module.exports = function(RED) {
                             canvas.height = playbackEl.videoHeight;
                             canvas.getContext('2d').drawImage(playbackEl, 0, 0);
                             var img = document.querySelector("img#ui_webcam_image_"+$scope.$id);
-                            img.src = canvas.toDataURL('image/png');
+                            img.src = canvas.toDataURL('image/'+($scope.config.format||'png'));
                             img.style.display = "block";
                             setTimeout(function() {
                                 img.style.display = "none";
@@ -314,7 +313,6 @@ module.exports = function(RED) {
                         function handleError(err) {
                             console.warn("Failed to access webcam:",err);
                             if (oldActiveCamera) {
-                                console.log("Going back to old");
                                 activeCamera = oldActiveCamera;
                                 oldActiveCamera = null;
                                 $scope.disableCamera();


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)


## Proposed changes

Adds a webcam node to the dashboard.

The node provides a live feed of the webcam and the user can click a button to capture an image.

Equally, if a message is passed to the node with `msg.capture` set to true, *and* the user has activated the webcam already, it will capture an image.

Captured images are set as a Buffer containing the png formatted image.

The node includes two options currently:
1. start webcam automatically (default: false) - will start the webcam when the dashboard is opened (prompting the user for permission etc). Otherwise the user has to click a button to turn on the camera.
2. use a countdown timer when taking a photo (default: false) - uses a 5 second countdown after clicking the button before taking the photo. This option is ignored if triggered remotely.

Lots of other possible options for this node, but this is an MVP to get started.

Quick demo: https://www.youtube.com/watch?v=8zoOqGZHzS4&feature=youtu.be



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
