### PR TITLE
Add mirror camera checkbox option

### DIFF
--- a/node-red-node-ui-webcam/package.json
+++ b/node-red-node-ui-webcam/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-node-ui-webcam",
-    "version": "0.2.2",
+    "version": "0.3.0",
     "description": "A Node-RED ui node to capture images from a webcam.",
     "author": "Nick O'Leary",
     "license": "Apache-2.0",

--- a/node-red-node-ui-webcam/ui_webcam.html
+++ b/node-red-node-ui-webcam/ui_webcam.html
@@ -35,6 +35,7 @@
             autoStart: { value: false },
             hideCaptureButton: { value: false },
             showImage: { value: 2 },
+            mirror: { value: true },
             format: { value:"png" }
         },
         inputs:1,
@@ -53,6 +54,10 @@
                 height: "#node-input-height",
                 group: "#node-input-group"
             });
+            if (this.mirror === undefined) {
+                this.mirror = true;
+                $("#node-input-mirror").attr("checked",true)
+            }
 
             var showImage = this.showImage === undefined ? 2 : this.showImage;
             if (showImage === 0) {
@@ -118,30 +123,35 @@
     <br />
     <div class="form-row" style="min-width: 470px">
         <label style="vertical-align: top"><i class="fa fa-cog"></i> Options</label>
-        <div style="display: inline-block; min-width: 350px; width: calc(100% - 120px);">
+        <div style="display:inline-block; min-width:350px; width:calc(100% - 120px);">
             <div class="form-row">
                 <label style="width: auto" for="node-input-autoStart">
-                    <input style="width:auto; margin: 0" type="checkbox" id="node-input-autoStart"> Start webcam automatically
+                    <input style="width:auto; margin:0" type="checkbox" id="node-input-autoStart"> Start webcam automatically
                 </label>
             </div>
             <div class="form-row">
                 <label style="width: auto" for="node-input-showImage-enable">
-                    <input style="width:auto; margin: 0" type="checkbox" id="node-input-showImage-enable"> Show image after capture
+                    <input style="width:auto; margin:0" type="checkbox" id="node-input-showImage-enable"> Show image after capture
                 </label>
                 <div class="node-row-ui-webcam-showImage-timeout">
-                    <label style="margin-bottom: 0; margin-left: 20px; width: auto" for="node-input-showImage-timeout">
-                        <input style="width:auto; margin: 0" type="checkbox" id="node-input-showImage-timeout"> Clear image after <input style="width:60px; margin: 0" type="text" id="node-input-showImage-time"> seconds
+                    <label style="margin-bottom:0; margin-left:20px; width:auto" for="node-input-showImage-timeout">
+                        <input style="width:auto; margin:0" type="checkbox" id="node-input-showImage-timeout"> Clear image after <input style="width:60px; margin: 0" type="text" id="node-input-showImage-time"> seconds
                     </label>
                 </div>
             </div>
             <div class="form-row">
                 <label style="width: auto" for="node-input-hideCaptureButton">
-                    <input style="width:auto; margin: 0" type="checkbox" id="node-input-hideCaptureButton"> Hide capture button
+                    <input style="width:auto; margin:0" type="checkbox" id="node-input-hideCaptureButton"> Hide capture button
                 </label>
             </div>
             <div class="form-row">
                 <label style="width: auto" for="node-input-countdown">
-                    <input style="width:auto; margin: 0" type="checkbox" id="node-input-countdown"> Use 5 second countdown when triggered
+                    <input style="width:auto; margin:0" type="checkbox" id="node-input-countdown"> Use 5 second countdown when triggered
+                </label>
+            </div>
+            <div class="form-row">
+                <label style="width: auto" for="node-input-mirror">
+                    <input style="width:auto; margin:0" type="checkbox" id="node-input-mirror"> Mirror image from webcam
                 </label>
             </div>
             <div class="form-row">
@@ -157,6 +167,7 @@
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
+    <div class="form-tips"><b>Tip</b>: most image processing nodes prefer jpeg formatted images.</b>
 </script>
 
 <script type="text/html" data-help-name="ui_webcam">

--- a/node-red-node-ui-webcam/ui_webcam.js
+++ b/node-red-node-ui-webcam/ui_webcam.js
@@ -21,6 +21,8 @@ module.exports = function(RED) {
 
     function HTML(config) {
         var configAsJson = JSON.stringify(config);
+        if (!config.hasOwnProperty("mirror")) { config.mirror = true; }
+        var mirror = config.mirror ? -1 : 1;
         var html = String.raw`
 <style>
     .nr-dashboard-ui_webcam {
@@ -45,8 +47,8 @@ module.exports = function(RED) {
         position: absolute;
         width: 100%;
         height: 100%;
-        -webkit-transform: scaleX(-1);
-        transform: scaleX(-1);
+        -webkit-transform: scaleX(`+mirror+`);
+        transform: scaleX(`+mirror+`);
     }
     .ui-webcam-playback-container {
         width: 100%;
@@ -329,8 +331,10 @@ module.exports = function(RED) {
                             canvas.width = playbackEl.videoWidth;
                             canvas.height = playbackEl.videoHeight;
                             var ctx = canvas.getContext('2d');
-                            ctx.translate(playbackEl.videoWidth, 0);
-                            ctx.scale(-1, 1);
+                            if ($scope.config.mirror === true) {
+                                ctx.translate(playbackEl.videoWidth, 0);
+                                ctx.scale(-1, 1);
+                            }
                             ctx.drawImage(playbackEl, 0, 0);
                             var img = document.querySelector("img#ui_webcam_image_"+$scope.$id);
                             img.src = canvas.toDataURL('image/'+($scope.config.format||'png'));


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This adds a checkbox option to flip/mirror the camera. Current default is to have it set to mirror so when sitting in front of the camera it moves the "right" way... This option lets you turn that off so it behave the "normal" way.  Default is still on.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
