### PR TITLE
make initial widget size of vega to be auto

### DIFF
--- a/node-red-node-ui-vega/ui_vega.html
+++ b/node-red-node-ui-vega/ui_vega.html
@@ -60,7 +60,7 @@
                     $("#node-input-size").toggleClass("input-error",!valid);
                     return valid;
                 }},
-            height: {value: 5},
+            height: {value: 0},
             vega: {value: null}
         },
         inputs: 1,


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Initial widget size of of `ui-vega` node is `0x5` as shown in the following screen shot .  Since this is an invalid value, this PR makes the initial widget size `auto`.

![スクリーンショット 2021-11-19 9 27 32](https://user-images.githubusercontent.com/30289092/142519025-ac2261f4-e0b4-4f45-b138-ff12897f29ec.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
