### PR TITLE
fix: able to set limits and setpoint to zero

### DIFF
--- a/node-red-node-ui-lineargauge/linear_gauge.js
+++ b/node-red-node-ui-lineargauge/linear_gauge.js
@@ -160,9 +160,9 @@ module.exports = function(RED) {
                             }
 
                             var payload = msg.payload;
-                            var highLimit = msg.highlimit || 80;
-                            var lowLimit=  msg.lowlimit || 20;
-                            var setpoint =  msg.setpoint || 50;
+                            var highLimit = msg.highlimit === 0 ? 0 : msg.highlimit || 80;
+                            var lowLimit  = msg.lowlimit  === 0 ? 0 : msg.lowlimit  || 20;
+                            var setpoint  = msg.setpoint  === 0 ? 0 : msg.setpoint  || 50;
                             var gaugeStart = 0										// this is the gauge starting position, should be left at zero
                             var gaugeEnd = 188                                      // this is the length of the gauge, if the gauge is to be longer, this value should be the sum of the heights of the scale areas
 


### PR DESCRIPTION
With the current implementation you cannot set any of the limits or the setpoint to zero, since 0 is falsy.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

You cannot set, e.g., low limit to 0 since 0 is falsy. Checking limits and setpoint for zero now and sets to 0 instead of default values in that case, which will confuse people.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red-nodes/blob/master/CONTRIBUTING.md)
